### PR TITLE
fix: incorrect openid-configuration path for Keycloak

### DIFF
--- a/R/auth.R
+++ b/R/auth.R
@@ -16,8 +16,12 @@
 #' }
 #' @export
 discover <- function(auth_server) {
-  openid_config_url <- auth_server
-  urltools::path(openid_config_url) <- ".well-known/openid-configuration"
+  # ensure url ends with a single slash
+  auth_server_no_slash <- gsub("/$", "", auth_server)
+  auth_server <- paste0(auth_server_no_slash, "/")
+
+  # retrieve configuration
+  openid_config_url <- paste0(auth_server, ".well-known/openid-configuration")
   response <- httr::GET(openid_config_url)
   httr::stop_for_status(response, task = "discover OpenID configuration")
   configuration <- httr::content(response)

--- a/man/MolgenisAuth-package.Rd
+++ b/man/MolgenisAuth-package.Rd
@@ -6,8 +6,7 @@
 \alias{MolgenisAuth-package}
 \title{MolgenisAuth: 'OpenID Connect' Discovery and Authentication}
 \description{
-Discover 'OpenID Connect' endpoints and authenticate
-    using device flow. Used by 'MOLGENIS' packages.
+Discover 'OpenID Connect' endpoints and authenticate using device flow. Used by 'MOLGENIS' packages.
 }
 \seealso{
 Useful links:
@@ -19,12 +18,13 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Sido Haakma \email{s.haakma@rug.nl} (\href{https://orcid.org/0000-0003-1278-9144}{ORCID})
+\strong{Maintainer}: Mariska Slofstra \email{m.k.slofstra@umcg.nl} (\href{https://orcid.org/0000-0002-0400-0468}{ORCID})
 
 Authors:
 \itemize{
   \item Fleur Kelpin \email{fleur@kelpin.nl} (\href{https://orcid.org/0000-0003-1527-5130}{ORCID})
   \item Tommy de Boer \email{t.de.boer01@umcg.nl} (\href{https://orcid.org/0000-0002-4492-7225}{ORCID})
+  \item Sido Haakma \email{s.haakma@rug.nl} (\href{https://orcid.org/0000-0003-1278-9144}{ORCID})
 }
 
 Other contributors:


### PR DESCRIPTION
`urltools::path` replaces the complete path in the URL after the domain. This breaks when using Keycloak because the configuration endpoint is behind another path (`.../realms/Armadillo` for example)