### PR TITLE
fix: add form encode

### DIFF
--- a/R/auth.R
+++ b/R/auth.R
@@ -60,13 +60,17 @@ discover <- function(auth_server) {
 #'
 #' @export
 device_flow_auth <-
-  function(endpoint, client_id, scopes = c("openid", "offline_access")) {
+  function(endpoint, client_id, scopes = c("openid", "offline_access"),
+           encode = c("json", "form"
+           )) {
+    encode <- match.arg(encode)
     stopifnot(
       inherits(endpoint, "oauth_endpoint"),
       is.character(client_id),
       is.character(endpoint$device)
     )
     response <- httr::POST(endpoint$device,
+      encode = encode,
       body = list(
         client_id = client_id,
         scope = paste(scopes, collapse = " ")
@@ -97,6 +101,7 @@ device_flow_auth <-
       pause_min = auth_res$interval,
       times = auth_res$expires_in / auth_res$interval,
       quiet = TRUE,
+      encode = encode,
       body = list(
         "client_id" = client_id,
         "grant_type" = "urn:ietf:params:oauth:grant-type:device_code",


### PR DESCRIPTION
For fetching device token from a KeyCloak server we need to use **form** encoding.

- [ ] **encode** is a new argument and must be set to **form** depending on the OIDC server in this case **form**
- [ ] We must add this to Armadillo client and tell our users
  - [ ] Can we fix the above by identifying the OIDC **encode** preference

### How to test

Checkout the PR and run this from RStudio

```Rscript
library(MolgenisArmadillo)
#library(MolgenisAuth)
source("R/auth.R")

url <- "https://auth1.molgenis.net/realms/Molgenis"

client_id <- "Dev-Armadillo-Test"

endpoint <- discover(url)
endpoint

encode <- "form"

credentials <- device_flow_auth(endpoint, client_id, encode=encode)
credentials$id_token
```