### PR TITLE
fix: add scopes to request body in token request

### DIFF
--- a/R/auth.R
+++ b/R/auth.R
@@ -113,7 +113,6 @@ device_flow_auth <- function(endpoint, client_id, scopes = c("openid", "offline_
   )
 }
 
-
 #' Request Token via Browser
 #'
 #' Opens a browser to allow the user to log in and obtain an ID token.
@@ -163,7 +162,9 @@ device_flow_auth <- function(endpoint, client_id, scopes = c("openid", "offline_
     param_set(
       auth_res$verification_uri_complete,
       "client_id",
-      client_id
+      client_id,
+      "scope",
+      paste(scopes, collapse = " ")
     )
   )
 }


### PR DESCRIPTION
Docs:
https://fusionauth.io/docs/lifecycle/authenticate-users/oauth/endpoints

search for: `/oauth2/token`
scroll to request body, see:

> scope
String
The optional scope you are requesting during this grant. This parameter may contain multiple scopes space separated. For example, the value of openid offline_access provides two scopes on the request.
> 
> Available grant types:
> 
> openid - This scope is used to request an id_token be returned in the response
> offline_access - This scope scope is used to request a refresh_token be returned in the response

We did add the scope in the device request, but not in the token one. 