### PR TITLE
fix: used fix delay based on interval parameter

### DIFF
--- a/R/auth.R
+++ b/R/auth.R
@@ -235,10 +235,14 @@ device_flow_auth <- function(endpoint, client_id, scopes = c("openid", "offline_
 #' @return A modified request object with retry logic added.
 #' @noRd
 .add_credential_retry <- function(req, auth_res) {
+  interval <- auth_res$interval
+  max_tries <- auth_res$expires_in / interval
+
   req |> req_retry(
-    max_tries = auth_res$expires_in / auth_res$interval,
+    max_tries = max_tries,
     is_transient = function(resp) {
       resp_status(resp) == 400
-    }
+    },
+    backoff = function(attempt) interval
   )
 }


### PR DESCRIPTION
## Issue
Currently we are using the httr2 default for retrying api requests, which is an exponential increase. When using `get_token` or `get_credentials` this can lead to long waits (e.g. 30 seconds) to completing the operation, especially if the user is taking time to login or request the token via the browser, which is annoying.

## Solution
Change backoff time to the value of `auth_res$interval`, which is 5 seconds. Recommended approach here:
https://datatracker.ietf.org/doc/html/rfc8628#section-3.5

```
The authorization request is still pending as the end user hasn't
      yet completed the user-interaction steps ([Section 3.3](https://datatracker.ietf.org/doc/html/rfc8628#section-3.3)).  The
      client SHOULD repeat the access token request to the token
      endpoint (a process known as polling).  Before each new request,
      the client MUST wait at least the number of seconds specified by
      the "interval" parameter of the device authorization response (see
      [Section 3.2](https://datatracker.ietf.org/doc/html/rfc8628#section-3.2)), or 5 seconds if none was provided, and respect any
      increase in the polling interval required by the "slow_down"
      error.```
      
## How to test
- Check CI green
- Install latest version of `molgenis-r-datashield`
- Start localhost and run:
```
armadillo.get_credentials("http://localhost:8080")
```
- Don't click 'submit', instead return to R and check that the following is displayed:
`Waiting 5s for retry backoff`
- Then press 'submit' and check function completes
